### PR TITLE
zipp 3.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zipp" %}
-{% set version = "3.7.0" %}
+{% set version = "3.8.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d
+  sha256: 56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad
 
 build:
   number: 0
-  noarch: python
-  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:
   host:
@@ -23,13 +23,15 @@ requirements:
     - setuptools_scm >=3.4.1
     - toml
   run:
-    - python >=3.7
+    - python
 
 test:
   source_files:
     - test_zipp.py
   requires:
     - pip
+    - pytest >=6
+    - pytest-cov
     # this is a downstream that has a version requirement on zipp
     - importlib_metadata
     - jaraco.itertools
@@ -37,8 +39,8 @@ test:
   imports:
     - zipp
   commands:
-    - python -m unittest test_zipp.py
     - pip check
+    - pytest --cov={{ name }} test_zipp.py
 
 about:
   home: https://github.com/jaraco/zipp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,6 @@ test:
     - test_zipp.py
   requires:
     - pip
-    - pytest >=6
-    - pytest-cov
     # this is a downstream that has a version requirement on zipp
     - importlib_metadata
     - jaraco.itertools
@@ -40,7 +38,7 @@ test:
     - zipp
   commands:
     - pip check
-    - pytest --cov={{ name }} test_zipp.py
+    - python -m unittest test_zipp.py
 
 about:
   home: https://github.com/jaraco/zipp

--- a/recipe/use-scm-version.patch
+++ b/recipe/use-scm-version.patch
@@ -1,8 +1,0 @@
---- setup.py	2020-01-22 08:13:39.000000000 +0100
-+++ setup.py	2020-01-21 19:36:41.000000000 +0100
-@@ -3,4 +3,4 @@
- import setuptools
- 
- if __name__ == "__main__":
--    setuptools.setup()
-+    setuptools.setup(use_scm_version=True)


### PR DESCRIPTION
Update zipp to 3.8.0

Bug Tracker: new open issues https://github.com/jaraco/zipp/issues
Upstream license: License file: https://github.com/jaraco/zipp/blob/master/LICENSE
Upstream Changelog: https://github.com/jaraco/zipp/blob/main/CHANGES.rst
Upstream setup.cfg: https://github.com/jaraco/zipp/blob/v3.8.0/setup.cfg
Upstream pyproject.toml: https://github.com/jaraco/zipp/blob/v3.8.0/pyproject.toml

The package zipp is mentioned inside the packages:
catalogue | importlib_metadata | importlib_resources | pep517

Actions:
1. Remove noarch
2. Skip py<37
3. Fix python in run