### PR TITLE
zipp 3.20.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/jaraco.test-feedstock/pr1/87eb4c3
-  - https://staging.continuum.io/prefect/fs/jaraco.text-feedstock/pr4/fd04e98

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - /prefect/fs/jaraco.test-feedstock/pr1/87eb4c3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
   - https://staging.continuum.io/prefect/fs/jaraco.test-feedstock/pr1/87eb4c3
+  - https://staging.continuum.io/prefect/fs/jaraco.text-feedstock/pr4/fd04e98

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - /prefect/fs/jaraco.test-feedstock/pr1/87eb4c3
+  - https://staging.continuum.io/prefect/fs/jaraco.test-feedstock/pr1/87eb4c3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ test:
     # this is a downstream that has a version requirement on zipp
     - importlib_metadata
     - jaraco.itertools
+    - jaraco.test
     - func_timeout
     - jaraco.functools
     - more-itertools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,8 @@ requirements:
   host:
     - pip
     - python
-    - setuptools
-    - setuptools_scm
+    - setuptools >=61.2
+    - setuptools_scm >=3.4.1
     - wheel
     - toml
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zipp" %}
-{% set version = "3.17.0" %}
+{% set version = "3.20.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0
+  sha256: 0145e43d89664cfe1a2e533adc75adafed82fe2da404b4bbb6b026c0157bdb31
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,10 +20,6 @@ requirements:
     - python
     - setuptools
     - wheel
-    # Add upper bound to get around circular dependency
-    # zipp->setuptools_scm->importlib_metadata->zipp,
-    # see https://github.com/conda-forge/zipp-feedstock/commit/94b9a99af3adb8060fb705cefe27f851028f9b9a
-    - setuptools_scm >=3.4.1,<7
     - toml
   run:
     - python
@@ -42,6 +38,7 @@ test:
     - func_timeout
     - jaraco.functools
     - more-itertools
+    - importlib_resources  # [py<39]
   commands:
     - pip check
     - python -m unittest tests/test_path.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - pip
     - python
     - setuptools
+    - setuptools_scm
     - wheel
     - toml
   run:
@@ -30,8 +31,8 @@ test:
   imports:
     - zipp
   requires:
+    - pytest >=6,!=8.1.*
     - pip
-    # this is a downstream that has a version requirement on zipp
     - jaraco.itertools
     - jaraco.test
     - func_timeout
@@ -40,7 +41,7 @@ test:
     - importlib_resources  # [py<39]
   commands:
     - pip check
-    - python -m unittest tests/test_path.py
+    - pytest tests
 
 about:
   home: https://github.com/jaraco/zipp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zipp" %}
-{% set version = "3.20.0" %}
+{% set version = "3.20.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0145e43d89664cfe1a2e533adc75adafed82fe2da404b4bbb6b026c0157bdb31
+  sha256: bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,6 @@ test:
   requires:
     - pip
     # this is a downstream that has a version requirement on zipp
-    - importlib_metadata
     - jaraco.itertools
     - jaraco.test
     - func_timeout


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5332](https://anaconda.atlassian.net/browse/PKG-5332)
- [Upstream repository](https://github.com/jaraco/zipp/tree/v3.20.2)


### Explanation of changes:

- Update version and sha256
- Update python version skip and dependencies
- Update test suite


[PKG-5332]: https://anaconda.atlassian.net/browse/PKG-5332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ